### PR TITLE
Delegate the import of the Router module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "onna-tracking",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "license": "MIT",
     "scripts": {
         "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     },
     "devDependencies": {
         "@angular/cli": "^1.5.4",
-        "@angular/common": "^4.4.4",
-        "@angular/compiler": "^4.4.6",
-        "@angular/compiler-cli": "^4.4.6",
-        "@angular/core": "^4.4.4",
-        "@angular/platform-browser": "^4.4.4",
-        "@angular/platform-browser-dynamic": "^4.4.4",
-        "@angular/router": "^4.4.6",
+        "@angular/common": ">=4.4.4",
+        "@angular/compiler": ">=4.4.4",
+        "@angular/compiler-cli": ">=4.4.4",
+        "@angular/core": ">=4.4.4",
+        "@angular/platform-browser": ">=4.4.4",
+        "@angular/platform-browser-dynamic": ">=4.4.4",
+        "@angular/router": ">=4.4.4",
         "@types/jasmine": "~2.5.53",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "~6.0.60",
@@ -45,9 +45,9 @@
     },
     "peerDependencies": {
         "rxjs": "^5.5.0",
-        "@angular/core": ">= 4.4.4",
+        "@angular/core": ">=4.4.4",
         "@angular/platform-browser": ">=4.4.4",
-        "@angular/router": ">= 4.4.4",
+        "@angular/router": ">=4.4.4",
         "@angular/common": ">=4.4.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,14 @@
         "zone.js": "^0.8.14"
     },
     "devDependencies": {
-        "@angular/cli": "^1.5.2",
-        "@angular/compiler": ">=4.4.4",
-        "@angular/compiler-cli": ">=4.4.4",
+        "@angular/cli": "^1.5.4",
+        "@angular/common": "^4.4.4",
+        "@angular/compiler": "^4.4.6",
+        "@angular/compiler-cli": "^4.4.6",
+        "@angular/core": "^4.4.4",
+        "@angular/platform-browser": "^4.4.4",
+        "@angular/platform-browser-dynamic": "^4.4.4",
+        "@angular/router": "^4.4.6",
         "@types/jasmine": "~2.5.53",
         "@types/jasminewd2": "~2.0.2",
         "@types/node": "~6.0.60",
@@ -33,17 +38,16 @@
         "karma-jasmine": "~1.1.0",
         "karma-jasmine-html-reporter": "^0.2.2",
         "protractor": "~5.1.2",
+        "rxjs": "^5.5.0",
         "ts-node": "~3.2.0",
         "tslint": "~5.7.0",
-        "typescript": "^2.3.4"
+        "typescript": "^2.6.2"
     },
     "peerDependencies": {
         "rxjs": "^5.5.0",
         "@angular/core": ">= 4.4.4",
         "@angular/platform-browser": ">=4.4.4",
-        "@angular/platform-browser-dynamic": ">=4.4.4",
         "@angular/router": ">= 4.4.4",
-        "@angular/common": ">=4.4.4",
-        "@angular/language-service": ">=4.4.4"
+        "@angular/common": ">=4.4.4"
     }
 }

--- a/src/app-demo/app.component.spec.ts
+++ b/src/app-demo/app.component.spec.ts
@@ -12,6 +12,7 @@ import {TrackingSessionData} from "../lib/tracking/tracking-session-data.model";
 import {TrackingData} from "../lib/tracking/tracking-data.model";
 import {BrowserModule} from "@angular/platform-browser";
 import {APP_BASE_HREF} from "@angular/common";
+import {RouterTestingModule} from '@angular/router/testing';
 
 @Injectable()
 class MyTrackingStorage implements TrackingStorage {
@@ -34,7 +35,8 @@ describe('AppComponent', () => {
     TestBed.configureTestingModule({
         imports: [
             BrowserModule,
-          TrackingModule.storage(MyTrackingStorage)
+            RouterTestingModule,
+            TrackingModule.storage(MyTrackingStorage)
         ],
       declarations: [
           AppComponent

--- a/src/lib/tracking/tracking.module.ts
+++ b/src/lib/tracking/tracking.module.ts
@@ -15,8 +15,7 @@ const PROVIDERS = [
 
 @NgModule({
     imports: [
-        CommonModule,
-        RouterModule.forRoot([])
+        CommonModule
     ],
     declarations: [
         TrackItDirective

--- a/src/test/tracking/track-it.directive.spec.ts
+++ b/src/test/tracking/track-it.directive.spec.ts
@@ -2,6 +2,7 @@ import {APP_BASE_HREF} from '@angular/common';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, DebugElement, Injectable} from '@angular/core';
 import {By, BrowserModule} from '@angular/platform-browser';
+import {RouterTestingModule} from '@angular/router/testing';
 import {TrackItService} from '../../lib/tracking/track-it.service';
 import {TrackingModule} from '../../lib/tracking/tracking.module';
 import {TrackingStorage} from '../../lib/tracking/tracking-storage';
@@ -44,6 +45,7 @@ describe('Directive: TrackIt', () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             imports: [
+                RouterTestingModule,
                 BrowserModule,
                 TrackingModule.storage(MyTrackingStorage)
             ],


### PR DESCRIPTION
Importing the Router causes error on third party packages that also import Router.

```package.json``` dependencies where also updated.